### PR TITLE
fix: ignore babel config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ function usePluginImport(options) {
         const plugins = [importMeta, [babelImport, options]]
 
         const result = babel.transformSync(code, {
+          configFile: false,
           ast: true,
           plugins,
           sourceFileName: id


### PR DESCRIPTION
when a project has a babel config (ex. babel.config.js), Plugin will transform code follow this config.and it may transform js file under node_modules.