### PR TITLE
babel transform in some case will need configFile

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ function usePluginImport(options) {
         const plugins = [importMeta, [babelImport, options]]
 
         const result = babel.transformSync(code, {
-          configFile: false,
           ast: true,
           plugins,
           sourceFileName: id


### PR DESCRIPTION
sorry, its all my fault 😂😂😂
last time ,i edit this file. 
and it caused this error `Internal server error: unknown: Unexpected reserved word 'await'`  when plugin transform file with babel .

