### PR TITLE
fix: add missing options.customStyleName

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export interface Options {
 	style?: string | boolean | ((name: string, file?: any) => string);
 	styleLibraryDirectory?: string;
 	customName?: (name: string, file: any) => string;
+	customStyleName?: (name: string) => string;
 	libraryDirectory?: string;
 	camel2DashComponentName?: boolean;
 }


### PR DESCRIPTION
add missing options.customStyleName which supported by babel-plugin-import