### PR TITLE
SourceMaps is closed by default.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ function usePluginImport(options) {
         const result = babel.transformSync(code, {
           ast: true,
           plugins,
-          sourceFileName: id
+          sourceFileName: id,
+          sourceMaps: true
         })
 
         return {


### PR DESCRIPTION
The row address of the source map is incorrect during debugging.